### PR TITLE
Add create with signer seeds

### DIFF
--- a/program/src/cpi.rs
+++ b/program/src/cpi.rs
@@ -140,3 +140,25 @@ pub struct CInstruction {
     /// Length of the data expected by the program instruction.
     pub data_len: u64,
 }
+
+/// A signer seed as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct CSignerSeed {
+    /// Seed bytes.
+    pub seed: *const u8,
+
+    /// Length of the seed bytes.
+    pub len: u64,
+}
+
+/// Signer as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct CSigner {
+    /// Seed bytes.
+    pub seeds: *const CSignerSeed,
+
+    /// Number of signers.
+    pub len: u64,
+}

--- a/program/src/system.rs
+++ b/program/src/system.rs
@@ -38,6 +38,27 @@ pub fn create_account(
     space: u64,
     owner: &Pubkey,
 ) {
+    create_account_signed(funder, account, lamports, space, owner, &[])
+}
+
+/// Create a new account with a program signed instruction.
+///
+/// # Arguments
+///
+/// * `funder`: Funding account.
+/// * `account`: New account.
+/// * `lamports`: Number of lamports to transfer to the new account.
+/// * `space`: Number of bytes of memory to allocate.
+/// * `owner`: Address of program that will own the new account.
+/// * `signer_seeds`: Seeds used to sign the instruction.
+pub fn create_account_signed(
+    funder: &AccountInfo,
+    account: &AccountInfo,
+    lamports: u64,
+    space: u64,
+    owner: &Pubkey,
+    signer_seeds: &[&[u8]],
+) {
     let instruction_accounts: [CAccountMeta; 2] = [funder.into(), account.into()];
 
     // -   0..4: instruction discriminator
@@ -60,7 +81,6 @@ pub fn create_account(
 
     // account infos and seeds
     let account_infos: [CAccountInfo; 2] = [funder.into(), account.into()];
-    let seeds: &[&[&[u8]]] = &[];
 
     #[cfg(target_os = "solana")]
     unsafe {
@@ -68,14 +88,14 @@ pub fn create_account(
             &instruction as *const CInstruction as *const u8,
             account_infos.as_ptr() as *const u8,
             account_infos.len() as u64,
-            seeds.as_ptr() as *const u8,
-            seeds.len() as u64,
+            signer_seeds.as_ptr() as *const u8,
+            signer_seeds.len() as u64,
         );
     }
 
     // keep clippy happy
     #[cfg(not(target_os = "solana"))]
-    core::hint::black_box(&(&instruction, &account_infos, &seeds));
+    core::hint::black_box(&(&instruction, &account_infos, &signer_seeds));
 }
 
 /// Transfer lamports between accounts.

--- a/program/src/system.rs
+++ b/program/src/system.rs
@@ -59,7 +59,9 @@ pub fn create_account_signed<const SEEDS: usize>(
     owner: &Pubkey,
     signer_seeds: &[&[u8]; SEEDS],
 ) {
-    let instruction_accounts: [CAccountMeta; 2] = [funder.into(), account.into()];
+    let mut instruction_accounts: [CAccountMeta; 2] = [funder.into(), account.into()];
+    // account being created is always a signer
+    instruction_accounts[1].is_signer = true;
 
     // -   0..4: instruction discriminator
     // -  4..12: lamports

--- a/program/src/system.rs
+++ b/program/src/system.rs
@@ -38,7 +38,7 @@ pub fn create_account(
     space: u64,
     owner: &Pubkey,
 ) {
-    create_account_signed(funder, account, lamports, space, owner, &[])
+    _create_account_signed::<0>(funder, account, lamports, space, owner, &[]);
 }
 
 /// Create a new account with a program signed instruction.
@@ -59,31 +59,6 @@ pub fn create_account_signed<const SEEDS: usize>(
     owner: &Pubkey,
     signer_seeds: &[&[u8]; SEEDS],
 ) {
-    let mut instruction_accounts: [CAccountMeta; 2] = [funder.into(), account.into()];
-    // account being created is always a signer
-    instruction_accounts[1].is_signer = true;
-
-    // -   0..4: instruction discriminator
-    // -  4..12: lamports
-    // - 12..20: account space
-    // - 20..52: owner pubkey
-    let mut instruction_data = [0; 52];
-    // create account instruction has a '0' discriminator
-    instruction_data[4..12].copy_from_slice(&lamports.to_le_bytes());
-    instruction_data[12..20].copy_from_slice(&space.to_le_bytes());
-    instruction_data[20..52].copy_from_slice(owner.as_ref());
-
-    let instruction = CInstruction {
-        program_id: &system_program::ID,
-        accounts: instruction_accounts.as_ptr(),
-        accounts_len: instruction_accounts.len() as u64,
-        data: instruction_data.as_ptr(),
-        data_len: instruction_data.len() as u64,
-    };
-
-    // account infos and seeds
-    let account_infos: [CAccountInfo; 2] = [funder.into(), account.into()];
-
     // signer seeds
     let mut seeds: [std::mem::MaybeUninit<CSignerSeed>; SEEDS] =
         unsafe { std::mem::MaybeUninit::uninit().assume_init() };
@@ -100,20 +75,7 @@ pub fn create_account_signed<const SEEDS: usize>(
         len: SEEDS as u64,
     }];
 
-    #[cfg(target_os = "solana")]
-    unsafe {
-        solana_program::syscalls::sol_invoke_signed_c(
-            &instruction as *const CInstruction as *const u8,
-            account_infos.as_ptr() as *const u8,
-            account_infos.len() as u64,
-            signer.as_ptr() as *const u8,
-            signer.len() as u64,
-        );
-    }
-
-    // keep clippy happy
-    #[cfg(not(target_os = "solana"))]
-    core::hint::black_box(&(&instruction, &account_infos, &signer));
+    _create_account_signed::<SEEDS>(funder, account, lamports, space, owner, &signer);
 }
 
 /// Transfer lamports between accounts.
@@ -159,4 +121,68 @@ pub fn transfer(from: &AccountInfo, recipient: &AccountInfo, amount: u64) {
     // keep clippy happy
     #[cfg(not(target_os = "solana"))]
     core::hint::black_box(&(&instruction, &account_infos, &seeds));
+}
+
+//-- Internal functions
+
+/// Create a new account.
+///
+/// This function is used to create a new account either with or without a program
+/// signed instruction.
+///
+/// # Arguments
+///
+/// * `funder`: Funding account.
+/// * `account`: New account.
+/// * `lamports`: Number of lamports to transfer to the new account.
+/// * `space`: Number of bytes of memory to allocate.
+/// * `owner`: Address of program that will own the new account.
+/// * `signer`: Seeds used to sign the instruction.
+fn _create_account_signed<const SEEDS: usize>(
+    funder: &AccountInfo,
+    account: &AccountInfo,
+    lamports: u64,
+    space: u64,
+    owner: &Pubkey,
+    signer: &[CSigner],
+) {
+    let mut instruction_accounts: [CAccountMeta; 2] = [funder.into(), account.into()];
+    // account being created is always a signer
+    instruction_accounts[1].is_signer = true;
+
+    // -   0..4: instruction discriminator
+    // -  4..12: lamports
+    // - 12..20: account space
+    // - 20..52: owner pubkey
+    let mut instruction_data = [0; 52];
+    // create account instruction has a '0' discriminator
+    instruction_data[4..12].copy_from_slice(&lamports.to_le_bytes());
+    instruction_data[12..20].copy_from_slice(&space.to_le_bytes());
+    instruction_data[20..52].copy_from_slice(owner.as_ref());
+
+    let instruction = CInstruction {
+        program_id: &system_program::ID,
+        accounts: instruction_accounts.as_ptr(),
+        accounts_len: instruction_accounts.len() as u64,
+        data: instruction_data.as_ptr(),
+        data_len: instruction_data.len() as u64,
+    };
+
+    // account infos
+    let account_infos: [CAccountInfo; 2] = [funder.into(), account.into()];
+
+    #[cfg(target_os = "solana")]
+    unsafe {
+        solana_program::syscalls::sol_invoke_signed_c(
+            &instruction as *const CInstruction as *const u8,
+            account_infos.as_ptr() as *const u8,
+            account_infos.len() as u64,
+            signer.as_ptr() as *const u8,
+            signer.len() as u64,
+        );
+    }
+
+    // keep clippy happy
+    #[cfg(not(target_os = "solana"))]
+    core::hint::black_box(&(&instruction, &account_infos, &signer));
 }

--- a/program/src/system.rs
+++ b/program/src/system.rs
@@ -38,7 +38,7 @@ pub fn create_account(
     space: u64,
     owner: &Pubkey,
 ) {
-    _create_account_signed::<0>(funder, account, lamports, space, owner, &[]);
+    _create_account_signed(funder, account, lamports, space, owner, &[]);
 }
 
 /// Create a new account with a program signed instruction.
@@ -75,7 +75,7 @@ pub fn create_account_signed<const SEEDS: usize>(
         len: SEEDS as u64,
     }];
 
-    _create_account_signed::<SEEDS>(funder, account, lamports, space, owner, &signer);
+    _create_account_signed(funder, account, lamports, space, owner, &signer);
 }
 
 /// Transfer lamports between accounts.
@@ -138,7 +138,7 @@ pub fn transfer(from: &AccountInfo, recipient: &AccountInfo, amount: u64) {
 /// * `space`: Number of bytes of memory to allocate.
 /// * `owner`: Address of program that will own the new account.
 /// * `signer`: Seeds used to sign the instruction.
-fn _create_account_signed<const SEEDS: usize>(
+fn _create_account_signed(
     funder: &AccountInfo,
     account: &AccountInfo,
     lamports: u64,


### PR DESCRIPTION
This PR adds a `create_account_signed` helper to have the option of creating an account using System program with a program signed instruction. This is required to create accounts with a PDA signer.